### PR TITLE
Feature/signup

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -20,6 +20,21 @@ export function signinUser({ email, password }) {
   });
 }
 
+export function signUpUser({ email, password }) {
+  return ((dispatch) => {
+    return axios.post(`${ROOT_URL}${PORT}/signup`, { email, password })
+      .then(response => {
+        // update state to be auth'd
+        dispatch({ type: AUTH_USER });
+        // Save token locally
+        localStorage.setItem('token', response.data.token)
+      })
+      .catch(error => {
+        dispatch({ type: AUTH_ERROR, payload: error });
+      });
+  });
+}
+
 export function signoutUser() {
   localStorage.removeItem('token')
   return { type: UNAUTH_USER }

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -6,6 +6,7 @@ import Signin from "./auth/signin";
 import Signout from './auth/signout';
 import Signup from './auth/signup';
 import CampaignIndex from './campaign/campaign_index'
+import RequireAuth from './auth/require_auth'
 
 export default class App extends Component {
   render() {
@@ -15,7 +16,7 @@ export default class App extends Component {
         <Route path={"/signin"} component={Signin}/>
         <Route path={"/signout"} component={Signout}/>
         <Route path={"/signup"} component={Signup}/>
-        <Route path={"/campaign/index"} component={CampaignIndex}/>
+        <Route path={"/campaign/index"} component={RequireAuth(CampaignIndex)}/>
       </div>
     );
   }

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -5,6 +5,7 @@ import Header from "./header";
 import Signin from "./auth/signin";
 import Signout from './auth/signout';
 import Signup from './auth/signup';
+import CampaignIndex from './campaign/campaign_index'
 
 export default class App extends Component {
   render() {
@@ -14,6 +15,7 @@ export default class App extends Component {
         <Route path={"/signin"} component={Signin}/>
         <Route path={"/signout"} component={Signout}/>
         <Route path={"/signup"} component={Signup}/>
+        <Route path={"/campaign/index"} component={CampaignIndex}/>
       </div>
     );
   }

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -7,12 +7,14 @@ import Signout from './auth/signout';
 import Signup from './auth/signup';
 import CampaignIndex from './campaign/campaign_index'
 import RequireAuth from './auth/require_auth'
+import Root from './root'
 
 export default class App extends Component {
   render() {
     return (
       <div className="App">
         <Header />
+        <Route path={"/"} component={Root}/>
         <Route path={"/signin"} component={Signin}/>
         <Route path={"/signout"} component={Signout}/>
         <Route path={"/signup"} component={Signup}/>

--- a/src/components/auth/require_auth.js
+++ b/src/components/auth/require_auth.js
@@ -1,0 +1,28 @@
+// Higher Order Component
+// You can wrap any route that needs auth before access in this and boom -> Auth'd routes
+
+import React, { Component } from "react";
+import { connect } from "react-redux";
+import { withRouter } from "react-router-dom";
+
+export default function(ComposedComponent) {
+  class Authentication extends Component {
+    componentWillMount() {
+      if (!this.props.authenticated) {
+        this.props.history.push("/signin");
+      }
+    }
+    componentWillUpdate(nextProps) {
+      if (!nextProps.authenticated) {
+        this.props.history.push("/signin");
+      }
+    }
+    render() {
+      return <ComposedComponent {...this.props} />;
+    }
+  }
+  function mapStateToProps(state) {
+    return { authenticated: state.auth.authenticated };
+  }
+  return withRouter(connect(mapStateToProps)(Authentication));
+}

--- a/src/components/auth/signin.js
+++ b/src/components/auth/signin.js
@@ -10,7 +10,7 @@ const required = value => (value ? undefined : 'Required')
 class Signin extends Component {
   shouldComponentUpdate(nextProps) {
     if (nextProps.authenticated == true) {
-      this.props.history.push("/feature");
+      this.props.history.push("/campaign/index");
     }
     return true;
   }

--- a/src/components/auth/signin.js
+++ b/src/components/auth/signin.js
@@ -2,6 +2,10 @@ import React, { Component } from "react";
 import { Field, reduxForm } from "redux-form";
 import { connect } from "react-redux";
 import * as actions from "../../actions";
+import { renderField } from '../form/field'
+
+// Passed down to field component to enable require="true"
+const required = value => (value ? undefined : 'Required')
 
 class Signin extends Component {
   shouldComponentUpdate(nextProps) {
@@ -38,23 +42,19 @@ class Signin extends Component {
         onSubmit={handleSubmit(this.handleFormSubmit.bind(this))}
       >
         <fieldset className="form-group">
-          <label>Email:</label>
           <Field
             name="email"
-            component="input"
-            type="text"
-            className="form-control"
-            required="true"
+            component={renderField}
+            type="email"
+            validate={[required]}
+            label="Email"
           />
-        </fieldset>
-        <fieldset className="form-group">
-          <label>password:</label>
           <Field
             name="password"
-            component="input"
+            component={renderField}
             type="password"
-            className="form-control"
-            required="true"
+            validate={[required]}
+            label="password"
           />
         </fieldset>
         {this.renderAlert()}

--- a/src/components/auth/signin.js
+++ b/src/components/auth/signin.js
@@ -22,7 +22,7 @@ class Signin extends Component {
   renderAlert() {
     if (this.props.errorMessage) {
       const [status, httpResponse] = [
-        this.props.errorMessage.statusText,
+        this.props.errorMessage.data.error || this.props.errorMessage.statusText,
         this.props.errorMessage.status
       ];
       return (

--- a/src/components/auth/signup.js
+++ b/src/components/auth/signup.js
@@ -1,15 +1,36 @@
-import React, { Component } from 'react'
-import { connect } from 'react-redux'
-import { Field, reduxForm } from 'redux-form'
-import * as actions from '../../actions'
-import { renderField } from '../form/field'
+import React, { Component } from "react";
+import { connect } from "react-redux";
+import { Field, reduxForm } from "redux-form";
+import * as actions from "../../actions";
+import { renderField } from "../form/field";
 
-const required = value => (value ? undefined : 'Required')
+// Passed down to our field component to set required="true"
+const required = value => (value ? undefined : "Required");
 
 class SignUp extends Component {
+  shouldComponentUpdate(nextProps) {
+    if (nextProps.authenticated == true) {
+      this.props.history.push("/feature");
+    }
+    return true;
+  }
 
-  handleFormSubmit({email, password }) {
-    this.props.signUpUser({ email, password })
+  handleFormSubmit({ email, password }) {
+    this.props.signUpUser({ email, password });
+  }
+
+  renderAlert() {
+    if (this.props.errorMessage) {
+      const [status, httpResponse] = [
+        this.props.errorMessage.data.error,
+        this.props.errorMessage.status
+      ];
+      return (
+        <div className="alert alert-danger">
+          <strong>Error</strong>: {`${status} - ${httpResponse}`}
+        </div>
+      );
+    }
   }
 
   render() {
@@ -38,29 +59,35 @@ class SignUp extends Component {
           label="Password Confirmation"
           validate={[required]}
         />
-        <button type="submit" className="btn btn-primary">Sign Up</button>
+        {this.renderAlert()}
+        <button type="submit" className="btn btn-primary">
+          Sign Up
+        </button>
       </form>
     );
   }
 }
 
 function validate(values) {
-  let errors = {}
+  let errors = {};
 
   if (values.password != values.password_confirmation) {
-    errors.password = 'Password and password confirmation don\'t match!'
+    errors.password = "Password and password confirmation don't match!";
   }
 
-  return errors
+  return errors;
 }
 
 function mapStateToProps(state) {
   return {
-    errorMessage: state.auth.error
-  }
+    errorMessage: state.auth.error,
+    authenticated: state.auth.authenticated
+  };
 }
 
-export default connect(mapStateToProps, actions)(reduxForm({
-  form:'SignUp',
-  validate
-})(SignUp));
+export default connect(mapStateToProps, actions)(
+  reduxForm({
+    form: "SignUp",
+    validate
+  })(SignUp)
+);

--- a/src/components/auth/signup.js
+++ b/src/components/auth/signup.js
@@ -1,50 +1,66 @@
-import React, { Component } from "react";
-import { Field, reduxForm } from "redux-form";
-import * as actions from "../../actions";
+import React, { Component } from 'react'
+import { connect } from 'react-redux'
+import { Field, reduxForm } from 'redux-form'
+import * as actions from '../../actions'
+import { renderField } from '../form/field'
 
-class Signup extends Component {
+const required = value => (value ? undefined : 'Required')
+
+class SignUp extends Component {
+
+  handleFormSubmit({email, password }) {
+    this.props.signUpUser({ email, password })
+  }
+
   render() {
     const { handleSubmit } = this.props;
-    console.log(this.props)
-    return (
-      <form onSubmit={handleSubmit}>
-        <fieldset className="form-group">
-          <label htmlFor="email">Email</label>
-          <Field name="email" component="input" type="email" className="form-control"/>
 
-          <label htmlFor="password">password</label>
-          <Field name="password" component="input" type="password" className="form-control"/>
-          <label htmlFor="passwordConfirm">passwordConfirm</label>
-          <Field name="passwordConfirm" component="input" type="password" className="form-control"/>
-        </fieldset>
-        <button action="submit" className="btn btn-primary">
-          Sign up
-        </button>
+    return (
+      <form onSubmit={handleSubmit(this.handleFormSubmit.bind(this))}>
+        <Field
+          name="email"
+          component={renderField}
+          type="email"
+          validate={[required]}
+          label="Email"
+        />
+        <Field
+          name="password"
+          component={renderField}
+          type="password"
+          label="Password"
+          validate={[required]}
+        />
+        <Field
+          name="password_confirmation"
+          component={renderField}
+          type="password"
+          label="Password Confirmation"
+          validate={[required]}
+        />
+        <button type="submit" className="btn btn-primary">Sign Up</button>
       </form>
     );
   }
 }
 
-// function validate(formProps) {
-//   const errors = {};
-//   if (formProps.password !== formProps.passwordConfirm) {
-//     errors.password = "Passwords must match";
-//   }
-//   console.log("pew");
-//   return errors;
-// }
+function validate(values) {
+  let errors = {}
 
-const validate = values => {
-  const errors = {}
-  if (values.password !== values.passwordConfirm) {
-    errors.age = 'Sorry, you must be at least 18 years old'
+  if (values.password != values.password_confirmation) {
+    errors.password = 'Password and password confirmation don\'t match!'
   }
+
   return errors
 }
 
-Signup = reduxForm({
-  form: "signup",
-  validate
-})(Signup);
+function mapStateToProps(state) {
+  return {
+    errorMessage: state.auth.error
+  }
+}
 
-export default Signup;
+export default connect(mapStateToProps, actions)(reduxForm({
+  form:'SignUp',
+  validate
+})(SignUp));

--- a/src/components/auth/signup.js
+++ b/src/components/auth/signup.js
@@ -10,7 +10,7 @@ const required = value => (value ? undefined : "Required");
 class SignUp extends Component {
   shouldComponentUpdate(nextProps) {
     if (nextProps.authenticated == true) {
-      this.props.history.push("/feature");
+      this.props.history.push("/campaign/index");
     }
     return true;
   }

--- a/src/components/campaign/campaign_index.js
+++ b/src/components/campaign/campaign_index.js
@@ -1,0 +1,9 @@
+import React, { Component } from 'react'
+
+export default class CampaignIndex extends Component {
+  render() {
+    return (
+      <div>CAMPAIGNS</div>
+    )
+  }
+}

--- a/src/components/form/field.js
+++ b/src/components/form/field.js
@@ -1,0 +1,12 @@
+// Used in our redux-forms
+// Nice little field component that can render validation errors
+
+import React, { Component } from 'react'
+
+export const renderField = ({ input, label, type, required, meta: { touched, error, warning } }) => (
+  <fieldset className="form-group">
+    <label htmlFor={input.name}>{label}</label>
+    <input className="form-control" {...input} type={type}/>
+    { touched && error && <span className="text-danger">{error}</span> }
+  </fieldset>
+)

--- a/src/components/root.js
+++ b/src/components/root.js
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const Root = () => {
+  return <div>Root/Index Path</div>
+}
+
+export default Root

--- a/src/reducers/auth_reducer.js
+++ b/src/reducers/auth_reducer.js
@@ -3,7 +3,7 @@ import { AUTH_USER, UNAUTH_USER, AUTH_ERROR } from "../actions/types";
 export default function(state = {}, action) {
   switch (action.type) {
     case AUTH_USER:
-      return { ...state, authenticated: true };
+      return { ...state, error: '', authenticated: true };
     case UNAUTH_USER:
       return { ...state, authenticated: false };
     case AUTH_ERROR:

--- a/src/reducers/auth_reducer.js
+++ b/src/reducers/auth_reducer.js
@@ -3,7 +3,7 @@ import { AUTH_USER, UNAUTH_USER, AUTH_ERROR } from "../actions/types";
 export default function(state = {}, action) {
   switch (action.type) {
     case AUTH_USER:
-      return { ...state, error: '', authenticated: true };
+      return { ...state, error: "", authenticated: true };
     case UNAUTH_USER:
       return { ...state, authenticated: false };
     case AUTH_ERROR:

--- a/test/actions/index_test.js
+++ b/test/actions/index_test.js
@@ -5,7 +5,7 @@ import moxios from "moxios";
 
 import { storageMock } from "./mock_local_storage";
 
-import { signinUser, signoutUser } from "../../src/actions/index";
+import { signinUser, signoutUser, signUpUser } from "../../src/actions/index";
 import { AUTH_USER, AUTH_ERROR, UNAUTH_USER } from "../../src/actions/types";
 
 global.localStorage = storageMock();
@@ -47,53 +47,118 @@ describe("AUTH ACTION", () => {
   afterEach(() => {
     moxios.uninstall();
   });
-
-  it("create a token on AUTH USER", done => {
-    moxios.stubRequest(url, {
-      status: 200,
-      response: {
-        data: {
-          token: "sample_token"
+  describe('signinUser()', () => {
+    it("create a token on AUTH USER", done => {
+      moxios.stubRequest(url, {
+        status: 200,
+        response: {
+          data: {
+            token: "sample_token"
+          }
         }
-      }
+      });
+
+      const expectedAction = { type: AUTH_USER };
+
+      let testData = { email: "test1@test.com", password: "1234" };
+      store.dispatch(signinUser(testData)).then(() => {
+        const actualAction = store.getActions();
+        expect(actualAction).to.eql(expectedAction);
+      });
+      done();
     });
 
-    const expectedAction = { type: AUTH_USER };
+    it("returns an error on AUTH_ERROR with 401", done => {
+      moxios.stubRequest(url, {
+        status: 401,
+        response: {
+          data: "Unauthorized",
+          status: 401
+        }
+      });
 
-    let testData = { email: "test1@test.com", password: "1234" };
-    store.dispatch(signinUser(testData)).then(() => {
+      const expectedAction = { type: AUTH_ERROR, payload: AuthFailure };
+
+      let testData = { email: "test1@test.com", password: "124" };
+      store.dispatch(signinUser(testData)).then(() => {
+        const actualAction = store.getActions();
+        expect(actualAction).to.eql(expectedAction);
+      });
+      done();
+    });
+  })
+
+  describe('signUpUser()', () => {
+    it("create a token on AUTH USER", done => {
+      moxios.stubRequest(url, {
+        status: 201,
+        response: {
+          data: {
+            token: "sample_token"
+          }
+        }
+      });
+
+      const expectedAction = { type: AUTH_USER };
+
+      let testData = { email: "test1@test.com", password: "1234" };
+      store.dispatch(signUpUser(testData)).then(() => {
+        const actualAction = store.getActions();
+        expect(actualAction).to.eql(expectedAction);
+      });
+      done();
+    });
+
+    it("returns an error on AUTH_ERROR with 401", done => {
+      moxios.stubRequest(url, {
+        status: 401,
+        response: {
+          data: "Unauthorized",
+          status: 401
+        }
+      });
+
+      const expectedAction = { type: AUTH_ERROR, payload: AuthFailure };
+
+      let testData = { email: "test1@test.com", password: "124" };
+      store.dispatch(signinUser(testData)).then(() => {
+        const actualAction = store.getActions();
+        expect(actualAction).to.eql(expectedAction);
+      });
+      done();
+    });
+
+    describe("if email is in use", () => {
+      it("returns an error on AUTH_ERROR with 422", done => {
+        moxios.stubRequest(url, {
+          status: 422,
+          response: {
+            data: "Email is in use",
+            status: 422
+          }
+        });
+
+        const expectedAction = { type: AUTH_ERROR, payload: AuthFailure };
+
+        let testData = { email: "test1@test.com", password: "124" };
+        store.dispatch(signinUser(testData)).then(() => {
+          const actualAction = store.getActions();
+          expect(actualAction).to.eql(expectedAction);
+        });
+        done();
+      });
+    })
+  })
+
+  describe('signoutUser()', () => {
+    it("returns authenticated false on UNAUTH_USER", () => {
+      beforeEach(() => {
+        localStorage.setItem("token", "test");
+      });
+
+      const expectedAction = { type: UNAUTH_USER };
       const actualAction = store.getActions();
-      expect(actualAction).to.eql(expectedAction);
+      expect(signoutUser()).to.eql(expectedAction);
     });
-    done();
-  });
-
-  it("returns an error on AUTH_ERROR", done => {
-    moxios.stubRequest(url, {
-      status: 401,
-      response: {
-        data: "Unauthorized",
-        status: 401
-      }
-    });
-
-    const expectedAction = { type: AUTH_ERROR, payload: AuthFailure };
-
-    let testData = { email: "test1@test.com", password: "124" };
-    store.dispatch(signinUser(testData)).then(() => {
-      const actualAction = store.getActions();
-      expect(actualAction).to.eql(expectedAction);
-    });
-    done();
-  });
-
-  it("returns authenticated false on UNAUTH_USER", () => {
-    beforeEach(() => {
-      localStorage.setItem("token", "test");
-    });
-
-    const expectedAction = { type: UNAUTH_USER };
-    const actualAction = store.getActions();
-    expect(signoutUser()).to.eql(expectedAction);
-  });
+  })
 });


### PR DESCRIPTION
# What does this PR do?

Adds the functionality for our signup feature. This includes

- An action creator for the signUp path, which duplicates a lot of code that could be refactored away.
- Adds a HOC named RequireAuth which we can wrap regular components in if we want to restrict access to only auth'd users.
- Added a campaign component and route which is wrapped in our require_auth HOC, simply just to check if this works as intended.
  - Can be wrapped at the route level, and simply redirects to `/signin` component if state isn't authenticated.
- slight tweak to how our forms:
  -  handle api errors better => they'll either grab the associated API error message now if its custom, if not available they'll grab whatever error `statusText` appears in the response.
  - Extraction of fields from form to component => allows us to standardise rendering, error handling and validation, [this is basically stolen from the redux-form documentation](https://redux-form.com/7.2.3/examples/fieldlevelvalidation/)
- if authentication errors occur we save them to our redux state, if auth at a later point succeeds we clear the errors state to prevent form errors from rendering unnecessarily. 
- Extended refactor of our reducer to handle SignIn action and the possible error responses that could come from it.