### PR TITLE
Feature/authentication v2

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -1,6 +1,6 @@
 import axios from "axios";
 
-import { AUTH_USER, UNAUTH_USER, AUTH_ERROR } from "./types";
+import { AUTH_USER, UNAUTH_USER, AUTH_ERROR, FETCH_CAMPAIGNS } from "./types";
 
 const ROOT_URL = "http://localhost:";
 const PORT = "3030";
@@ -38,4 +38,19 @@ export function signUpUser({ email, password }) {
 export function signoutUser() {
   localStorage.removeItem('token')
   return { type: UNAUTH_USER }
+}
+
+export function fetchCampaigns() {
+  return ((dispatch) => {
+    return axios.get(`${ROOT_URL}${PORT}/campaign/index`, {
+      headers: { authorization: localStorage.getItem('token') }
+    })
+      .then(response => {
+        console.log(response.data)
+        dispatch({ type: FETCH_CAMPAIGNS, payload: response.data})
+      })
+      .catch(error => {
+        dispatch({ type: AUTH_ERROR, payload: error})
+      });
+  });
 }

--- a/src/actions/types.js
+++ b/src/actions/types.js
@@ -2,3 +2,4 @@ export const SUBMIT_LOGIN = "submit_login";
 export const AUTH_USER = "auth_user";
 export const UNAUTH_USER = "unauth_user";
 export const AUTH_ERROR = "auth_error";
+export const FETCH_CAMPAIGNS = "fetch_campaigns";

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -14,7 +14,7 @@ export default class App extends Component {
     return (
       <div className="App">
         <Header />
-        <Route path={"/"} component={Root}/>
+        <Route exact path={"/"} component={Root}/>
         <Route path={"/signin"} component={Signin}/>
         <Route path={"/signout"} component={Signout}/>
         <Route path={"/signup"} component={Signup}/>

--- a/src/components/campaign/campaign_index.js
+++ b/src/components/campaign/campaign_index.js
@@ -1,9 +1,21 @@
 import React, { Component } from 'react'
+import { connect } from 'react-redux';
+import * as actions from '../../actions/index'
 
-export default class CampaignIndex extends Component {
+class CampaignIndex extends Component {
+  componentWillMount() {
+    this.props.fetchCampaigns();
+  }
   render() {
     return (
-      <div>CAMPAIGNS</div>
+      <div>{this.props.campaigns}</div>
     )
   }
 }
+
+function mapStateToProps(state) {
+  return {
+    campaigns: state.campaigns.fetch_message
+  };
+}
+export default connect(mapStateToProps, actions)(CampaignIndex)

--- a/src/components/campaign/campaign_index.js
+++ b/src/components/campaign/campaign_index.js
@@ -6,11 +6,29 @@ class CampaignIndex extends Component {
   componentWillMount() {
     this.props.fetchCampaigns();
   }
+
+  renderItems(){
+    return this.props.campaigns.map((item) => {
+      return (
+        <div key={item.id}>id: {item.id} - name: {item.name} </div>
+      )
+    })
+  }
+
   render() {
+    if(!this.props.campaigns){
+      return <div>Loading...</div>
+    }
+
     return (
       <div>
-        <p>Success:{this.props.campaigns}</p>
-        <p>Fail:{this.props.error.data}</p>
+        <h4>successfull fetch shows up here</h4>
+        --------------------------------------
+        {this.renderItems()}
+        --------------------------------------
+        <h4>Fails show up here (errors from API)</h4>
+        --------------------------------------
+        {this.props.error.data}
       </div>
     )
   }
@@ -18,7 +36,7 @@ class CampaignIndex extends Component {
 
 function mapStateToProps(state) {
   return {
-    campaigns: state.campaigns.fetch_message,
+    campaigns: state.campaigns.collection,
     error: state.auth.error
   };
 }

--- a/src/components/campaign/campaign_index.js
+++ b/src/components/campaign/campaign_index.js
@@ -8,14 +8,18 @@ class CampaignIndex extends Component {
   }
   render() {
     return (
-      <div>{this.props.campaigns}</div>
+      <div>
+        <p>Success:{this.props.campaigns}</p>
+        <p>Fail:{this.props.error.data}</p>
+      </div>
     )
   }
 }
 
 function mapStateToProps(state) {
   return {
-    campaigns: state.campaigns.fetch_message
+    campaigns: state.campaigns.fetch_message,
+    error: state.auth.error
   };
 }
 export default connect(mapStateToProps, actions)(CampaignIndex)

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import ReactDOM from "react-dom";
 import { Provider } from "react-redux";
 import { createStore, applyMiddleware, compose } from "redux";
 import { BrowserRouter, Route } from "react-router-dom";
+import { AUTH_USER } from "./actions/types";
 
 import reduxThunk from 'redux-thunk'
 
@@ -10,10 +11,19 @@ import App from "./components/app";
 import reducers from "./reducers";
 
 const createStoreWithMiddleware = applyMiddleware(reduxThunk)(createStore);
+const reduxDevToolsStore = window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
+const store = createStoreWithMiddleware(reducers, reduxDevToolsStore)
+
+// If token found set state to authenticated
+const token = localStorage.getItem('token')
+
+if (token) {
+  store.dispatch({ type: AUTH_USER})
+}
 
 ReactDOM.render(
-  <Provider store={createStoreWithMiddleware(reducers, window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__())}>
-    <BrowserRouter >
+  <Provider store={store}>
+    <BrowserRouter>
       <Route path="/" component={App}/>
     </BrowserRouter>
   </Provider>,

--- a/src/reducers/campaign_reducer.js
+++ b/src/reducers/campaign_reducer.js
@@ -1,0 +1,10 @@
+import { FETCH_CAMPAIGNS } from "../actions/types";
+
+export default function(state = {}, action) {
+  switch (action.type) {
+    case FETCH_CAMPAIGNS:
+      return { ...state, fetch_message: action.payload.message };
+  }
+
+  return state;
+}

--- a/src/reducers/campaign_reducer.js
+++ b/src/reducers/campaign_reducer.js
@@ -3,7 +3,7 @@ import { FETCH_CAMPAIGNS } from "../actions/types";
 export default function(state = {}, action) {
   switch (action.type) {
     case FETCH_CAMPAIGNS:
-      return { ...state, fetch_message: action.payload.message };
+      return { ...state, collection: action.payload };
   }
 
   return state;

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,10 +1,12 @@
 import { combineReducers } from 'redux';
 import { reducer as form } from 'redux-form';
 import authReducer from './auth_reducer'
+import campaignReducer from './campaign_reducer'
 
 const rootReducer = combineReducers({
   form,
-  auth: authReducer
+  auth: authReducer,
+  campaigns: campaignReducer
 });
 
 export default rootReducer;

--- a/test/actions/index_test.js
+++ b/test/actions/index_test.js
@@ -5,8 +5,8 @@ import moxios from "moxios";
 
 import { storageMock } from "./mock_local_storage";
 
-import { signinUser, signoutUser, signUpUser } from "../../src/actions/index";
-import { AUTH_USER, AUTH_ERROR, UNAUTH_USER } from "../../src/actions/types";
+import { signinUser, signoutUser, signUpUser, fetchCampaigns } from "../../src/actions/index";
+import { AUTH_USER, AUTH_ERROR, UNAUTH_USER, FETCH_CAMPAIGNS } from "../../src/actions/types";
 
 global.localStorage = storageMock();
 
@@ -38,7 +38,7 @@ const mockStore = configureMockStore(middlewares);
 let store;
 let url;
 
-describe("AUTH ACTION", () => {
+describe("AUTH ACTIONS", () => {
   beforeEach(() => {
     moxios.install();
     store = mockStore({});
@@ -162,3 +162,66 @@ describe("AUTH ACTION", () => {
     });
   })
 });
+
+describe("CAMPAIGN ACTIONS", () => {
+  beforeEach(() => {
+    moxios.install();
+    store = mockStore({});
+    url = "http://localhost:3030";
+  });
+
+  afterEach(() => {
+    moxios.uninstall();
+  });
+
+  let header = { token: 'pew'}
+
+  it("returns success message and dispatches FETCH_CAMPAIGNS", done => {
+    const fetchSuccess = {
+      response: {
+        data: {
+          message: "yaaay"
+        }
+      }
+    };
+
+    moxios.stubRequest(
+      header,
+      url, {
+      status: 200,
+      response: {
+        data: {
+          message: "yaaaay"
+        }
+      }
+    });
+
+    const expectedAction = { type: FETCH_CAMPAIGNS, payload: fetchSuccess };
+
+    store.dispatch(fetchCampaigns()).then(() => {
+      const actualAction = store.getActions();
+      expect(actualAction).to.eql(expectedAction);
+    });
+    done();
+  })
+
+  it("returns error message on error and dispatches AUTH_ERROR", done => {
+    moxios.stubRequest(url, {
+        status: 401,
+        response: {
+          data: "Unauthorized",
+          status: 401
+        }
+      });
+
+      const expectedAction = { type: AUTH_ERROR, payload: AuthFailure };
+
+      store.dispatch(fetchCampaigns()).then(() => {
+        const actualAction = store.getActions();
+        expect(actualAction).to.eql(expectedAction);
+      });
+      done();
+  })
+})
+
+

--- a/test/reducers/auth_reducer_test.js
+++ b/test/reducers/auth_reducer_test.js
@@ -2,7 +2,7 @@ import { expect } from "../test_helper";
 import reducer from '../../src/reducers/auth_reducer'
 import { AUTH_USER, AUTH_ERROR, UNAUTH_USER } from "../../src/actions/types";
 
-describe('auth reducer', () => {
+describe('Auth reducer', () => {
   it('should return the initial state', () => {
     expect(reducer(undefined, {})).to.eql({})
   })
@@ -13,7 +13,8 @@ describe('auth reducer', () => {
         type: AUTH_USER
       })
     ).to.eql({
-      authenticated: true
+      authenticated: true,
+      error: ''
     })
   })
 

--- a/test/reducers/campaign_reducer.js
+++ b/test/reducers/campaign_reducer.js
@@ -1,0 +1,26 @@
+import { expect } from "../test_helper";
+import reducer from "../../src/reducers/campaign_reducer";
+import { FETCH_CAMPAIGNS } from "../../src/actions/types";
+
+describe("Campaign reducer", () => {
+  it("should return the initial state", () => {
+    expect(reducer(undefined, {})).to.eql({});
+  });
+
+  it("should handle FETCH_CAMPAIGNS", () => {
+    let success_response = {
+      message: "YAAY for making authorized requests bro"
+    };
+
+    expect(
+      reducer({},
+        {
+          type: FETCH_CAMPAIGNS,
+          payload: success_response
+        }
+      )
+    ).to.eql({
+      fetch_message: "YAAY for making authorized requests bro"
+    });
+  });
+});

--- a/test/reducers/campaign_reducer.js
+++ b/test/reducers/campaign_reducer.js
@@ -8,19 +8,26 @@ describe("Campaign reducer", () => {
   });
 
   it("should handle FETCH_CAMPAIGNS", () => {
-    let success_response = {
-      message: "YAAY for making authorized requests bro"
-    };
+    let success_response = [
+      { id: 1, name: "test1" },
+      { id: 2, name: "test1" },
+      { id: 3, name: "test1" }
+    ];
 
     expect(
-      reducer({},
+      reducer(
+        {},
         {
           type: FETCH_CAMPAIGNS,
           payload: success_response
         }
       )
     ).to.eql({
-      fetch_message: "YAAY for making authorized requests bro"
+      collection: [
+        { id: 1, name: "test1" },
+        { id: 2, name: "test1" },
+        { id: 3, name: "test1" }
+      ]
     });
   });
 });


### PR DESCRIPTION
# What does this PR do?

Adds a FETCH_CAMPAIGN action creator &  reducer so when our user reaches an auth'd state and then access the protected path `/campaign/index`, another thunk promise can be dispatched and return a list of items or an error.

- Action creator makes API request using token stored in localStorage as a header for auth
- updated `components/campaign/campaign_index` to either render a collection of items from API or API Error response
- New action creator & reducer for `FETCH_CAMPAIGNS`
  - Just a dummy route that spits out a collection 
  - Route is hidden behind auth and can only be accessed by attaching user Auth Token in header of request
  - associated tests

- Cleanup up the initialization of redux store
  - on initialization will now check for an auth token in `localStorage`
  - abstracted some store config to constants for readability
